### PR TITLE
CDF tools for confidence envelopes

### DIFF
--- a/mirabolic/__init__.py
+++ b/mirabolic/__init__.py
@@ -1,9 +1,12 @@
 import os
 
-with open(os.path.join(os.path.dirname(__file__), 'version'), mode='r') as fp:
+with open(os.path.join(os.path.dirname(__file__), "version"), mode="r") as fp:
     __version__ = fp.readline().rstrip()
 
 # We import some functions/classes for ease of reference.
+
+# Tool for plotting CDFs with confidence intervals
+from mirabolic.cdf.cdf_tools import cdf_plot
 
 # Tensorflow loss functions for count data
 from mirabolic.neural_glm.actuarial_loss_functions import (

--- a/mirabolic/cdf/cdf_tools.py
+++ b/mirabolic/cdf/cdf_tools.py
@@ -1,0 +1,304 @@
+# Given a set of data, compute and plot confidence intervals
+# for the corresponding CDF.
+
+import numpy as np
+import matplotlib.pyplot as plt
+import seaborn as sns
+import pandas as pd
+from scipy.stats import binom, beta
+from scipy.special import loggamma
+from scipy import interpolate
+
+# The beta distribution is the correct (pointwise) distribution
+# across *quantiles* for a given *data point*; if you're not
+# sure, this is probably the estimator you want to use.
+
+
+def CDF_CI_marginal_quick(a=None, N=None, confidence=None, **kwargs):
+    # The marginal distribution is beta-distributed, and this calculates a
+    # (marginal) confidence interval exactly.  This interval is guaranteed
+    # to contain the mode, but is not necessarily the smallest possible
+    # confidence interval.
+
+    b = N + 1 - a
+
+    if a == 1:
+        lower = 0
+        upper = beta.ppf(confidence, a, b)
+        if np.isnan(upper):
+            print("sefes")
+            import IPython
+            IPython.embed()
+        return (lower, upper)
+    if a == N:
+        lower = beta.ppf(1 - confidence, a, b)
+        upper = 1
+        return (lower, upper)
+
+    mode = (a - 1) / (a + b - 2)
+    mode_cumu_prob = beta.cdf(mode, a, b)
+    lower_prob = mode_cumu_prob - confidence * mode_cumu_prob
+    upper_prob = mode_cumu_prob + confidence * (1 - mode_cumu_prob)
+    lower = beta.ppf(lower_prob, a, b)
+    upper = beta.ppf(upper_prob, a, b)
+
+    if np.isnan(lower):
+        import IPython
+        IPython.embed()
+    return (lower, upper)
+
+
+def CDF_CI_marginal_opt(a=None, N=None, confidence=None, max_steps=6, **kwargs):
+    # The marginal distribution is beta-distributed, and this calculates a
+    # (marginal) confidence interval exactly.  There are different choices
+    # for the confidence interval.  If N>1, then there is a unique shortest
+    # confidence interval; because the beta distribution is (usually)
+    # asymmetric, computing this interval requires a little work.  (We use
+    # Newton's method to optimize.)
+
+    b = N + 1 - a
+
+    if a==1:
+        lower = 0
+        upper = beta.ppf(confidence, a, b)
+        import IPython
+        IPython.embed()
+        return (lower, upper)
+    if a==N:
+        lower = beta.ppf(1 - confidence, a, b)
+        upper = 1
+        return (lower, upper)
+
+    # Choose a reasonable starting guess
+    lower, upper = CDF_CI_marginal_quick(i=i, N=N, confidence=confidence, **kwargs)
+
+    # We want a relatively small step size in the context of our
+    # distribution
+    delta = 0.1 / (N ** 2)
+
+    B_norm = np.exp(loggamma(a+b) - loggamma(a) - loggamma(b))
+
+    # lower_guess should always be in [0, max_lower_guess]
+    max_lower = beta.ppf(1 - confidence, a, b)
+
+    def recover_upper(lower):
+        return beta.ppf(beta.cdf(lower, a, b) + confidence, a, b)
+
+    def f_0(lower):
+        # f_0 should be monotonically increasing for a,b>=2
+        upper = recover_upper(lower)
+        b_lower = beta.pdf(lower, a, b)
+        b_upper = beta.pdf(upper, a, b)
+        return b_lower - b_upper
+
+    def f_1(lower, f_left=None):
+        if f_left is None:
+            f_left = f_0(lower)
+        f_right = f_0(lower + delta)
+        return (f_right - f_left) / delta
+
+    for step in range(max_steps):
+        f_0_val = f_0(lower)
+        f_1_val = f_1(lower, f_left=f_0_val)
+        step = f_0_val / f_1_val
+        lower = lower - step
+        # delta = min(delta, np.abs(step) / 100)
+        if step < delta:
+            break
+
+    return (lower, recover_upper(lower))
+
+
+# Compute Dvoretzky-Kiefer-Wolfowitz confidence bands.
+def CDF_CI_DKW(a=None, N=None, confidence=None, **kwargs):
+    # See, e.g.,
+    # https://en.wikipedia.org/wiki/Dvoretzky%E2%80%93Kiefer%E2%80%93Wolfowitz_inequality
+    epsilon = np.sqrt(np.log(2.0 / confidence) / (2.0 * float(N)))
+
+    y = ecdf_value(a, N, ecdf_type="classical")
+    return (y - epsilon, y + epsilon)
+
+
+def confidence_interval_bounds(**kwargs):
+    bound = kwargs["bound"]
+    if bound == "DKW":
+        fn = CDF_CI_DKW
+    elif bound == "marginal_quick":
+        fn = CDF_CI_marginal_quick
+    elif bound == "marginal_opt":
+        fn = CDF_CI_marginal_opt
+    else:
+        raise ValueError(f"Unknown bound {bound}")
+
+    lower, upper = fn(**kwargs)
+    if lower < 0:
+        lower = 0
+    if upper > 1:
+        upper = 1
+
+    return (lower, upper)
+
+
+def ecdf_value(a=None, N=None, ecdf_type=None, bound=None):
+    assert a <= N
+
+    # Note that the DKW inequality assumes the "classic"
+    # definition of the empirical CDF, namely
+    #
+    #  ecdf(x) = (# samples <= x) / (# samples)
+    #
+    # However, we compute marginal CIs by minimizing
+    # the size of the CI for the beta distribution; for
+    # small confidence values, ecdf(x) may not
+    # lie within the CI.  If, instead, we use the mode of the
+    # beta distribution, we are guaranteed to fall within
+    # the CI.
+    #
+    # So, we select the type of ecdf based on the estimator.
+    if ecdf_type is None:
+        if bound == "marginal_quick" or "marginal_opt":
+            ecdf_type = "mode"
+        elif bound == "DKW":
+            ecdf_type = "classical"
+        else:
+            raise ValueError(f"Unknown bound {bound}")
+
+    if ecdf_type == "classical":
+        return a / N
+    elif ecdf_type == "mean":
+        return a / (N + 1)
+    elif ecdf_type == "mode":
+        return (a-1) / (N - 1)
+    else:
+        ValueError(f"Unknown cdf_type {ecdf_type}")
+
+
+def CDF_plot(
+    # Key arguments
+    data=None,
+    confidence=0.9,  # How wide is the confidence interval/band?
+    # Statistical and control parameters
+    presorted=False,  # Is the data already sorted?
+    bound="marginal_quick",  # What kind of CI? (E.g., DKW or marginal?)
+    ecdf_type=None,  # Exactly how do we define the empirical CDF?
+    max_points=128,  # How many points to compute?
+    # Plotting parameters
+    plot_figure=True,  # Should we plot the data (or only return the results?)
+    color=None,
+    ax=None,
+    plot_central_kw=None,  # Arguments to pass to plot(CDF)
+    plot_confidence_kw=None,  # Arguments to pass to plot(confidence band)
+    seaborn=True,
+):
+    """
+    Given a collection of real-valued observations, plot a CDF with a
+    confidence band around the values.
+    """
+
+    # Check input arguments
+    assert confidence >= 0 and confidence <= 1
+    assert bound in {"marginal_quick", "marginal_opt", "DKW"}
+    assert ecdf_type in {"classical", "mode", "mean", None}
+
+    # Clean up data types
+    if isinstance(data, pd.core.series.Series):
+        # Extract data from PANDAS data frame
+        data = data.values
+    if not isinstance(data, np.ndarray):
+        # Try to convert, e.g., list to Numpy array
+        data = np.array(data)
+
+    N = len(data)
+    if N == 0:
+        raise ValueError("Data length is zero!")
+
+    # Make sure we have numbers...
+    assert np.issubdtype(data.dtype, np.number)
+    # Make sure no NaNs or Infs...
+    if not np.isfinite(data).all():
+        bad_index = np.min(np.where(~np.isfinite(data)))
+        print(f"data[{bad_index}] = {data[bad_index]}")
+        raise ValueError("Nonfinite values!")
+
+    # Sort data if necessary
+    if presorted == False:
+        # We can't risk overwriting the original data, so we
+        # make a copy.  (If data is presorted, we can skip this
+        # and save the memory).
+        data = np.sort(data)
+
+    # If we have a lot of data, then we neither want nor need to
+    # plot every point-- it would be very slow to compute, memory
+    # intensive to plot, and uninformative (because the envelope
+    # won't change much).  Instead, we plot only "max_points".
+    # If you really want to plot everything, set that value to 0 or None.
+    if max_points is None or max_points < 1:
+        N_plot = N
+    N_plot = min(N, max_points)
+    # Choose N_plot numbers evenly spread between 0 and N-1 (inclusive)
+    index_list = np.linspace(0, N-1, N_plot).round().astype(int)
+
+    # Compute estimates
+    x = []
+    y = []
+    y_lower = []
+    y_upper = []
+    for i in index_list:
+        a=i+1
+        x.append(data[i])  # i-th largest value
+        y.append(ecdf_value(a=a, N=N, ecdf_type=ecdf_type, bound=bound))
+        if N == 1:
+            # Special case N==1 to avoid possible edge cases
+            tail = (1.0 - confidence) / 2
+            y_lower.append(tail)
+            y_upper.append(1 - tail)
+            break
+
+        lower, upper = confidence_interval_bounds(
+            a=a, N=N, confidence=confidence, bound=bound
+        )
+        y_lower.append(lower)
+        y_upper.append(upper)
+
+    if plot_figure:
+        # Use Seaborn defaults if desired
+        if seaborn:
+            sns.set()
+
+        # Use specified or default Matplotlib axis
+        if ax is None:
+            ax = plt.gca()
+
+        if plot_central_kw is None:
+            plot_central_kw = {}
+        if plot_confidence_kw is None:
+            plot_confidence_kw = {}
+
+        default_plot_confidence_kw = dict(alpha=0.3)
+        default_plot_confidence_kw.update(plot_confidence_kw)
+        plot_confidence_kw = default_plot_confidence_kw
+        if color is not None:
+            plot_central_kw.update({"color": color})
+            plot_confidence_kw.update({"color": color})
+
+        plt.plot(x, y, **plot_central_kw)
+        plt.fill_between(x, y_lower, y_upper, **plot_confidence_kw)
+        print(y_lower[:5], y_upper[:5])
+
+    results = dict(x=x, y=y, y_lower=y_lower, y_upper=y_upper)
+    return results
+
+
+data = np.random.randn(500)
+print(1)
+plt.figure()
+results = CDF_plot(data=data)
+print(2)
+#plt.figure()
+#CDF_plot(data=data, bound="marginal_opt")
+print(3)
+#plt.figure()
+#CDF_plot(data=data, bound="DKW")
+print(4)
+
+plt.show()

--- a/mirabolic/cdf/cdf_tools.py
+++ b/mirabolic/cdf/cdf_tools.py
@@ -182,7 +182,7 @@ def cdf_plot(
     confidence=0.9,  # How wide is the confidence interval/band?
     # Statistical and control parameters
     presorted=False,  # Is the data already sorted?
-    bound="marginal_quick",  # What kind of CI? (E.g., DKW or marginal?)
+    bound="marginal_opt",  # What kind of CI? (E.g., DKW or marginal?)
     ecdf_type=None,  # Exactly how do we define the empirical CDF?
     max_points=128,  # How many points to compute?
     # Plotting parameters
@@ -270,7 +270,7 @@ def cdf_plot(
     if plot_figure:
         # Use Seaborn defaults if desired
         if seaborn:
-            sns.set()
+            sns.set_theme()
 
         # Use specified or default Matplotlib axis
         if ax is None:
@@ -291,5 +291,16 @@ def cdf_plot(
         plt.plot(x, y, **plot_central_kw)
         plt.fill_between(x, y_lower, y_upper, **plot_confidence_kw)
 
-    results = dict(x=x, y=y, y_lower=y_lower, y_upper=y_upper, index_list=index_list)
+    DKW_epsilon_bound = None
+    if bound == "DKW":
+        DKW_epsilon_bound = 1 - y_lower[-1]
+
+    results = dict(
+        x=x,
+        y=y,
+        y_lower=y_lower,
+        y_upper=y_upper,
+        index_list=index_list,
+        DKW_epsilon_bound=DKW_epsilon_bound,
+    )
     return results

--- a/mirabolic/cdf/sample_usage.py
+++ b/mirabolic/cdf/sample_usage.py
@@ -1,0 +1,70 @@
+import numpy as np
+import seaborn as sns
+import matplotlib.pyplot as plt
+
+import mirabolic
+
+# We provide examples of plotting a CDF with a confidence
+# envelope using mirabolic.cdf_plot()
+
+# Make some data to plot
+data = np.random.randn(120)
+
+
+##############
+# A basic plot
+#
+# By default, we use a "90% marginal credibility interval",
+# which means that if take any data point, there is a 90%
+# probability that it falls within the shaded region above
+# it (so, we should think of a vertical interval).  Note
+# that the chance that *all* the data points jointly fall
+# in their credibility interval is less than 90%; if you
+# want a joint bound, see the next example.
+plt.figure()
+mirabolic.cdf_plot(data=data, seaborn=True)
+plt.title("Figure 1: Default behavior\n90% Marginal CI")
+
+
+################################################################
+# The DKW Inequality gives us a bound that *all* the data points
+# will *simultaneously* fall within the confidence envelope.
+plt.figure()
+mirabolic.cdf_plot(data=data, bound="DKW", confidence=0.75, color="purple")
+plt.title("Figure 2: Joint bound (DKW)\nProbability all data lies envelope is >=75% ")
+
+
+##################
+# Fancier plotting
+f, (ax1, ax2) = plt.subplots(1, 2)
+
+plot_central_kw = {"color": "green", "linestyle": "dotted", "marker": "o"}
+plot_confidence_kw = {"color": "blue", "alpha": 0.1}
+mirabolic.cdf_plot(
+    data=data,
+    bound="DKW",
+    ax=ax2,
+    plot_central_kw=plot_central_kw,
+    plot_confidence_kw=plot_confidence_kw,
+)
+f.suptitle("Figure 3: Fancier Plotting")
+ax1.set_title("Histogram")
+ax1.hist(data)
+
+ax2.set_title("CDF")
+ax2.plot([0, 1], [0, 0.8], color="red")
+plt.tight_layout()
+
+
+###########################
+# Cut corners to run faster
+sorted_data = np.sort(data)
+
+plt.figure()
+plt.title("Figure 4: Speed up compute & rendering")
+mirabolic.cdf_plot(
+    data=sorted_data, presorted=True, bound="marginal_quick", max_points=64
+)
+
+
+plt.show()

--- a/mirabolic/cdf/unit_tests/test_cdf_tools.py
+++ b/mirabolic/cdf/unit_tests/test_cdf_tools.py
@@ -1,0 +1,131 @@
+# Some unit tests (to be run through "pytest") to validate
+# "cdf_tools.cdf_plot()". We focus less on code edge cases
+# and more on checking statistical correctness.
+
+import numpy as np
+import sys
+import os
+import matplotlib.pyplot as plt
+from scipy.stats import beta
+
+# Get parent directory on import path
+current = os.path.dirname(os.path.realpath(__file__))
+parent = os.path.dirname(current)
+sys.path.append(parent)
+
+# Import "cdf_plot" (from parent directory)
+from cdf_tools import cdf_plot
+
+
+def wassert(x, warning):
+    if not x:
+        print(warning)
+        assert x
+
+
+def vec_assert(x, warning):
+    for i in range(len(x)):
+        if not x[i]:
+            print(warning + f":  x[{i}]={x[i]}")
+            assert x[i]
+
+
+def test_minimal():
+    # Make sure it runs without crashing and quantiles are in [0,1].
+    # Low bar to success :)
+    N = 100
+    unsorted_data = np.random.randn(N)
+    sorted_data = np.sort(unsorted_data)
+    for presorted in [True, False]:
+        if presorted:
+            data = sorted_data
+        else:
+            data = unsorted_data
+        for bound in ["marginal_quick", "marginal_opt", "DKW"]:
+            warning1 = f"ERROR MESSAGE: sorted={sorted}, N={N}, bound={bound}"
+            for confidence in [0, 0.5, 0.95, 1.0]:
+                warning2 = warning1 + f", conf={confidence}"
+                for plot_figure in [True, False]:
+                    results = cdf_plot(
+                        data=data,
+                        bound=bound,
+                        confidence=confidence,
+                        plot_figure=plot_figure,
+                        presorted=presorted,
+                    )
+                    if plot_figure:
+                        plt.close(plt.gcf())
+                for k in ["y", "y_lower", "y_upper"]:
+                    warning3 = warning2 + f", k={k}"
+                    r = results[k]
+                    # Check that the quantiles actually lie in [0, 1]
+                    vec_assert(np.isfinite(r), warning3)
+                    vec_assert(r <= 1.0, warning3)
+                    vec_assert(r >= 0.0, warning3)
+
+
+def test_statistical():
+    # Let's check that the statistics work correctly.
+
+    num_trials = 10000
+    N_list = [3, 4, 15, 512]
+    confidence_list = [0.5, 0.95]
+
+    for N in N_list:
+        data = np.random.randn(N)
+        for confidence in confidence_list:
+            warning1 = f"ERROR: N={N}, conf={confidence}"
+            # Test marginals (pointwise CI)
+            for bound in ["marginal_quick", "marginal_opt"]:
+                warning2 = warning1 + f", bound={bound}"
+                results = cdf_plot(
+                    data=data, bound=bound, confidence=confidence, plot_figure=False
+                )
+                i_len = len(results["index_list"])
+                i_list = np.unique([0, 1, i_len // 2, i_len - 1])
+                a_list = results["index_list"][i_list] + 1
+                for a, i in zip(a_list, i_list):
+                    warning3 = warning2 + f", x={i}"
+                    b = N + 1 - a
+                    # The following check presupposes that (1) beta() in scipy
+                    # works correctly, and (2) we are interpreting the math
+                    # correctly.  But if so, it's fast and exact
+                    prob = beta.cdf(results["y_upper"][i], a, b) - beta.cdf(
+                        results["y_lower"][i], a, b
+                    )
+                    warning3 += f", conf={confidence}, prob={prob}"
+                    wassert(np.isclose(prob, confidence), warning3)
+
+            # Test envelope (DKW)
+            bound = "DKW"
+            success_count = 0
+            for trial in range(num_trials):
+                results = cdf_plot(
+                    data=np.random.uniform(size=N),
+                    bound=bound,
+                    confidence=confidence,
+                    plot_figure=False,
+                )
+                if (results["x"] >= results["y_lower"]).all() and (
+                    results["x"] <= results["y_upper"]
+                ).all():
+                    success_count += 1
+            success_prob = success_count / num_trials
+
+            # The DKW bound guarantees that, in expectation,
+            #    success_prob >= confidence
+            # If we are "lucky", it may be tighter and
+            #    success_prob ~= confidence
+            # In the latter case, if we take a Monte Carlo
+            # estimate of "success_prob", we may still observe
+            #    sampled(success_prob) < confidence
+            # (say) half the time.  To avoid this, we add a few
+            # standard deviations (a "fudge factor") to account
+            # for the risk of sampling noise.  (Since the underlying
+            # samples are Bernoulli, that's easy to compute.)
+            fudge_sigmas = 6
+            fudge_factor = np.sqrt(success_prob * (1 - success_prob) / num_trials)
+            fudged_success_prob = success_prob + fudge_sigmas * fudge_factor
+
+            check = fudged_success_prob > confidence
+            assert check


### PR DESCRIPTION
If you have a set of data and want to plot the CDF, but wish you had something like a confidence interval, then this is the tool for you.  There is one main entry point, `cdf_plot()`; the typical usage is
```
cdf_plot(data=[1.3, 2.3535, ....])
```
which produces a plot of the CDF of the data with 90% (marginal) confidence intervals.  Simple examples can be found in `mirabolic/cdf/sample_usage.py`.

We highlight a few somewhat non-obvious points:
- By default, the confidence envelope is computed marginally (i.e., we refer to the probability of the quantile of any specific value).  If you prefer a joint bound on all the data simulatneously, use the `bound="DKW"` kwarg.
- By default, we only compute the confidence on 128 evenly spaced data points; this can be controlled with the `max_points` kwarg, and setting it to `0` or `None` will compute the value for all data points.
- By default, we compute the smallest marginal confidence interval; this is asymmetric but is guaranteed to include the mode of the marginal distribution.

Unit tests are included and take about 30 seconds to run using `pytest`.