### PR TITLE
Faster import

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,11 @@ and the source code can be found at https://github.com/Mirabolic/mirabolic
 
 ## CDF Confidence Intervals
 
-When exploring data, it can be very helpful to plot observations as a [CDF](https://en.wikipedia.org/wiki/Cumulative_distribution_function).  Producing a CDF essentially amounts to sorting the observed data from smallest to largest.  We hope that the value in the middle of the sorted list is near the median, the value 90% of the way up the list is near the 90th percentile, and so forth.
+When exploring data, it can be very helpful to plot observations as a [CDF](https://en.wikipedia.org/wiki/Cumulative_distribution_function).  Producing a CDF essentially amounts to sorting the observed data from smallest to largest.  We can treat[^iid] the value in the middle of the sorted list as approximately the median, the value 90% of the way up the list is near the 90th percentile, and so forth.
 
-When interpreting a CDF, or comparing two of them, one often wishes for something akin to a confidence interval.  Somewhat surprisingly, it is possible to compute these intervals exactly.[^Beta]
+[^iid]: We assume the data consists of i.i.d. draws from some unknown probability distribution.
+
+When interpreting a CDF, or comparing two of them, one often wishes for something akin to a confidence interval.  How close is the middle value to the median?  Somewhat surprisingly, it is possible to compute the corresponding confidence intervals exactly.[^Beta]
 
 [^Beta]: More precisely, suppose we draw a sample of n observations and consider the i-th smallest; if we are sampling from *any* continuous probability distribution, then the distribution of the corresponding quantile has a [Beta distribution](https://en.wikipedia.org/wiki/Beta_distribution), B(i, n-i+1).
 
@@ -19,7 +21,11 @@ For a single data point, the uncertainty around its quantile can be thought of a
 
 We provide a simple function for plotting CDFs with confidence bands; one invokes it by calling something like:
 ```
+import mirabolic
+import matplotlib.pyplot as plt
+
 mirabolic.cdf_plot(data=[17.2, 5.1, 13, ...])
+plt.show()
 ```
 
 More examples can be found in (`mirabolic/cdf/sample_usage.py`)[https://github.com/Mirabolic/mirabolic/blob/main/mirabolic/cdf/sample_usage.py].
@@ -28,7 +34,23 @@ More examples can be found in (`mirabolic/cdf/sample_usage.py`)[https://github.c
 
 GLMs ([Generalized Linear Models](https://en.wikipedia.org/wiki/Generalized_linear_model)) are a relatively broad class of statistical model first popularlized in the 1970s.  These have grown popular in the actuarial literature as a method of predicting insurance claims costs and frequency.
 
-With the appropriate loss function, GLMs can be formulated as types of neural nets.  To illustrate this, we perform [Poisson regression](https://en.wikipedia.org/wiki/Poisson_regression) in Keras using a nearly trivial network and a custom loss function.  Expressing a GLM as a neural net opens the possibility of extending the neural net before or after the GLM component.  For instance, suppose we build three subnets that each computed a single feature, and then feed the three outputs as inputs into the Poisson regression net.  This single larger network would allow the three subnets to engineer their individual features such that the loss function of the joint network was optimized.  This approach provides a straightforward way of performing non-linear feature engineering but retaining the explainability of a GLM.
+With the appropriate loss function, GLMs can be formulated as types of neural nets.  This connection provides two advantages.  First, a vast amount of effort has been spent on optimizing and accelerating neural nets over the past several years (GPUs and TPUs, parallelization); by expressing a GLM as a neural net, we can leverage this work.  Second, if we wish to extend beyond linear models, we can start with a GLM and then gracefully increase complexity.
+
+We provide corresponding loss functions for several of the most commonly used GLMs.  The corresponding code might look something like this:
+```
+import mirabolic.neural_glm as neural_glm
+from keras.models import Sequential
+import tf
+
+model = Sequential()
+# Actually make your neural net...
+# model.add(...)
+loss=neural_glm.Poisson_link_with_exposure
+optimizer = tf.keras.optimizers.Adam(learning_rate=lr_schedule)
+model.compile(loss=neural_glm, optimizer=optimizer)
+```
+
+To illustrate this process in more detail, we perform [Poisson regression](https://en.wikipedia.org/wiki/Poisson_regression) in Keras using a nearly trivial network and a custom loss function.  Expressing a GLM as a neural net opens the possibility of extending the neural net before or after the GLM component.  For instance, suppose we build three subnets that each computed a single feature, and then feed the three outputs as inputs into the Poisson regression net.  This single larger network would allow the three subnets to engineer their individual features such that the loss function of the joint network was optimized.  This approach provides a straightforward way of performing non-linear feature engineering but retaining the explainability of a GLM.
 
 To see the code in action, run
 ```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Mirabolic
-Tools for statistical modeling and analysis.
+Tools for statistical modeling and analysis, written by [Mirabolic](https://www.mirabolic.net/).  These modules can be installed by running
+```
+pip install --upgrade mirabolic
+```
+and the source code can be found at
+
+https://github.com/Mirabolic/mirabolic
 
 ## CDF Confidence Intervals
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ When exploring data, it can be very helpful to plot observations as a [CDF](http
 
 When interpreting a CDF, or comparing two of them, one often wishes for something akin to a confidence interval.  Somewhat surprisingly, it is possible to compute these intervals exactly.[^1]
 
-^1: More precisely, suppose we draw a sample of $n$ observations and consider the $i$-th smallest; if we are sampling from *any* continuous probability distribution, then the distribution of the corresponding quantile has a [Beta distribution](https://en.wikipedia.org/wiki/Beta_distribution), $B(i, n-i+1)$.
+[^1]: More precisely, suppose we draw a sample of $n$ observations and consider the $i$-th smallest; if we are sampling from *any* continuous probability distribution, then the distribution of the corresponding quantile has a [Beta distribution](https://en.wikipedia.org/wiki/Beta_distribution), $B(i, n-i+1)$.
 
 For a single data point, the uncertainty around its quantile can be thought of as a confidence interval (actually, a (credible interval)[https://en.wikipedia.org/wiki/Credible_interval], since we know the prior distribution).  If we consider all the data points, then we refer to a confidence band (or credible band)
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When interpreting a CDF, or comparing two of them, one often wishes for somethin
 
 For a single data point, the uncertainty around its quantile can be thought of as a confidence interval.  If we consider all the data points, then we refer to a *confidence band*.[^Credible]
 
-[^Credible]: Because we have access to a prior distribution on quantiles, these are arguably *credible intervals* (see https://en.wikipedia.org/wiki/Credible_interval) and *credible bands*, rather than confidence intervals and bands.  We do not concern ourselves with this detail.
+[^Credible]: Because we have access to a prior distribution on quantiles, these are arguably *[credible intervals](https://en.wikipedia.org/wiki/Credible_interval)* and *credible bands*, rather than confidence intervals and bands.  We do not concern ourselves with this detail.
 
 We provide a simple function for plotting CDFs with confidence bands; one invokes it by calling something like:
 ```

--- a/README.md
+++ b/README.md
@@ -9,13 +9,15 @@ and the source code can be found at https://github.com/Mirabolic/mirabolic
 
 When exploring data, it can be very helpful to plot observations as a [CDF](https://en.wikipedia.org/wiki/Cumulative_distribution_function).  Producing a CDF essentially amounts to sorting the observed data from smallest to largest.  We hope that the value in the middle of the sorted list is near the median, the value 90% of the way up the list is near the 90th percentile, and so forth.
 
-When interpreting a CDF, or comparing two of them, one often wishes for something akin to a confidence interval.  Somewhat surprisingly, it is possible to compute these intervals exactly.[^1]
+When interpreting a CDF, or comparing two of them, one often wishes for something akin to a confidence interval.  Somewhat surprisingly, it is possible to compute these intervals exactly.[^Beta]
 
-[^1]: More precisely, suppose we draw a sample of $n$ observations and consider the $i$-th smallest; if we are sampling from *any* continuous probability distribution, then the distribution of the corresponding quantile has a [Beta distribution](https://en.wikipedia.org/wiki/Beta_distribution), $B(i, n-i+1)$.
+[^Beta]: More precisely, suppose we draw a sample of n observations and consider the i-th smallest; if we are sampling from *any* continuous probability distribution, then the distribution of the corresponding quantile has a [Beta distribution](https://en.wikipedia.org/wiki/Beta_distribution), B(i, n-i+1).
 
-For a single data point, the uncertainty around its quantile can be thought of as a confidence interval (actually, a (credible interval)[https://en.wikipedia.org/wiki/Credible_interval], since we know the prior distribution).  If we consider all the data points, then we refer to a confidence band (or credible band)
+For a single data point, the uncertainty around its quantile can be thought of as a confidence interval.  If we consider all the data points, then we refer to a *confidence band*.[^Credible]
 
-We provide a simple function for plotting CDFs with credible bands; one invokes it by calling something like:
+[^Credible]: Because we have access to a prior distribution on quantiles, these are arguably *(credible intervals)[https://en.wikipedia.org/wiki/Credible_interval]* and *credible bands*, rather than confidence intervals and bands.  We do not concern ourselves with this detail.
+
+We provide a simple function for plotting CDFs with confidence bands; one invokes it by calling something like:
 ```
 mirabolic.cdf_plot(data=[17.2, 5.1, 13, ...])
 ```

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ When examining data, it can be very helpful to plot data as a [CDF](https://en.w
 a CDF, or comparing two of them, one often wishes for something akin to a
 confidence interval.
 
-Somewhat surprisingly, it is possible to compute these intervals exactly.  (More precisely, suppose we draw n samples and consider the i-th smallest; if the probability distribution is continuous, then the distribution of the corresponding quantile has a Beta distribution.)
+Somewhat surprisingly, it is possible to compute these intervals exactly.  (More precisely, suppose we draw a sample of $n$ observations and consider the $i$-th smallest; if the probability distribution is continuous, then the distribution of the corresponding quantile has a [Beta distribution](https://en.wikipedia.org/wiki/Beta_distribution).)
 
 We provide a simple function for plotting CDFs with credibility envelopes; one invokes
 it by calling something like:

--- a/README.md
+++ b/README.md
@@ -9,19 +9,18 @@ https://github.com/Mirabolic/mirabolic
 
 ## CDF Confidence Intervals
 
-When examining data, it can be very helpful to plot data as a [CDF](https://en.wikipedia.org/wiki/Cumulative_distribution_function).  When interpreting
-a CDF, or comparing two of them, one often wishes for something akin to a
-confidence interval.
+When examining data, it can be very helpful to plot data as a [CDF](https://en.wikipedia.org/wiki/Cumulative_distribution_function).  Producing a CDF essentially amounts to sorting our observed data from smallest to largest.  We hope that the value in the middle of the sorted list is near the median, the value 90% of the way up the list is near the 90th percentile, and so forth.
 
-Somewhat surprisingly, it is possible to compute these intervals exactly.  (More precisely, suppose we draw a sample of $n$ observations and consider the $i$-th smallest; if the probability distribution is continuous, then the distribution of the corresponding quantile has a [Beta distribution](https://en.wikipedia.org/wiki/Beta_distribution).)
+When interpreting a CDF, or comparing two of them, one often wishes for something akin to a confidence interval.  Somewhat surprisingly, it is possible to compute these intervals exactly.  (More precisely, suppose we draw a sample of $n$ observations and consider the $i$-th smallest; if we are sampling from *any* continuous probability distribution, then the distribution of the corresponding quantile has a [Beta distribution](https://en.wikipedia.org/wiki/Beta_distribution), $B(i, n-i+1)$.)
 
-We provide a simple function for plotting CDFs with credibility envelopes; one invokes
-it by calling something like:
+For a single data point, the uncertainty around its quantile can be thought of as a confidence interval (actually, a (credible interval)[https://en.wikipedia.org/wiki/Credible_interval], since we know the prior distribution).  If we consider all the data points, then we refer to a confidence band (or credible band)
+
+We provide a simple function for plotting CDFs with credible bands; one invokes it by calling something like:
 ```
 mirabolic.cdf_plot(data=[17.2, 5.1, 13, ...])
 ```
 
-More simple examples can be found in `mirabolic/cdf/sample_usage.py`
+More examples can be found in (`mirabolic/cdf/sample_usage.py`)[https://github.com/Mirabolic/mirabolic/blob/main/mirabolic/cdf/sample_usage.py].
 
 ## Neural Nets for GLM regression
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ When interpreting a CDF, or comparing two of them, one often wishes for somethin
 
 For a single data point, the uncertainty around its quantile can be thought of as a confidence interval.  If we consider all the data points, then we refer to a *confidence band*.[^Credible]
 
-[^Credible]: Because we have access to a prior distribution on quantiles, these are arguably *(credible intervals)[https://en.wikipedia.org/wiki/Credible_interval]* and *credible bands*, rather than confidence intervals and bands.  We do not concern ourselves with this detail.
+[^Credible]: Because we have access to a prior distribution on quantiles, these are arguably *credible intervals* (see https://en.wikipedia.org/wiki/Credible_interval) and *credible bands*, rather than confidence intervals and bands.  We do not concern ourselves with this detail.
 
 We provide a simple function for plotting CDFs with confidence bands; one invokes it by calling something like:
 ```

--- a/README.md
+++ b/README.md
@@ -34,28 +34,33 @@ More examples can be found in (`mirabolic/cdf/sample_usage.py`)[https://github.c
 
 GLMs ([Generalized Linear Models](https://en.wikipedia.org/wiki/Generalized_linear_model)) are a relatively broad class of statistical model first popularlized in the 1970s.  These have grown popular in the actuarial literature as a method of predicting insurance claims costs and frequency.
 
-With the appropriate loss function, GLMs can be formulated as types of neural nets.  This connection provides two advantages.  First, a vast amount of effort has been spent on optimizing and accelerating neural nets over the past several years (GPUs and TPUs, parallelization); by expressing a GLM as a neural net, we can leverage this work.  Second, if we wish to extend beyond linear models, we can start with a GLM and then gracefully increase complexity.
+With the appropriate loss function, GLMs can be expressed as neural nets.  These two techniques have traditionally been treated as distinct, but bridging the divide provides two advantages.
 
-We provide corresponding loss functions for several of the most commonly used GLMs.  The corresponding code might look something like this:
+First, a vast amount of effort has been spent on optimizing and accelerating neural nets over the past several years (GPUs and TPUs, parallelization).  By expressing a GLM as a neural net, we can leverage this work.[^NN]
+
+[^NN]: In terms of focus, [this chart](https://trends.google.com/trends/explore?geo=US&q=deep%20learning,actuarial%20science) suggests something of the explosion of interest in neural nets and deep learning relative to more traditional actuarial models.
+
+Second, expressing a GLM as a neural net opens the possibility of extending the neural net before or after the GLM component.  For instance, suppose we build three subnets that each computed a single feature, and then feed the three outputs as inputs into the Poisson regression net.  This single larger network would allow the three subnets to engineer their individual features such that the loss function of the joint network was optimized.  This approach provides a straightforward way of performing non-linear feature engineering but retaining the explainability of a GLM.  This two-step approach may provide regulatory advantages, since US Departments of Insurance (DOIs) have been reluctant to approve end-to-end deep learning models.
+
+We provide loss functions for several of the most commonly used GLMs.  Minimal code might look something like this:
 ```
 import mirabolic.neural_glm as neural_glm
 from keras.models import Sequential
 import tf
 
 model = Sequential()
-# Actually make your neural net...
+# Actually design your neural net...
 # model.add(...)
 loss=neural_glm.Poisson_link_with_exposure
-optimizer = tf.keras.optimizers.Adam(learning_rate=lr_schedule)
+optimizer = tf.keras.optimizers.Adam()
 model.compile(loss=neural_glm, optimizer=optimizer)
 ```
 
-To illustrate this process in more detail, we perform [Poisson regression](https://en.wikipedia.org/wiki/Poisson_regression) in Keras using a nearly trivial network and a custom loss function.  Expressing a GLM as a neural net opens the possibility of extending the neural net before or after the GLM component.  For instance, suppose we build three subnets that each computed a single feature, and then feed the three outputs as inputs into the Poisson regression net.  This single larger network would allow the three subnets to engineer their individual features such that the loss function of the joint network was optimized.  This approach provides a straightforward way of performing non-linear feature engineering but retaining the explainability of a GLM.
+To illustrate this process in more detail, we provide code to perform [Poisson regression](https://en.wikipedia.org/wiki/Poisson_regression) and Negative Binomial regression using a neural net.  
 
-To see the code in action, run
+To see the code in action, grab [the source code](https://github.com/Mirabolic/mirabolic) from GitHub, then [change to this directory](https://github.com/Mirabolic/mirabolic/tree/main/mirabolic/neural_glm), and run
 ```
-python sample_poisson.py
+python run_examples.py
 ```
-This will generate some Poisson-distributed data and corresponding features and then try to recover the "betas" (i.e., the linear coefficients of the GLM), outputting both the true and recovered values.
+This will generate Poisson-distributed data and corresponding features and then try to recover the "betas" (i.e., the linear coefficients of the GLM) using various models, outputting both the true and recovered values.
 
-We also include the loss function required for negative binomial regression, which can be useful when modeling count data with higher variance.

--- a/README.md
+++ b/README.md
@@ -3,15 +3,15 @@ Tools for statistical modeling and analysis, written by [Mirabolic](https://www.
 ```
 pip install --upgrade mirabolic
 ```
-and the source code can be found at
-
-https://github.com/Mirabolic/mirabolic
+and the source code can be found at https://github.com/Mirabolic/mirabolic
 
 ## CDF Confidence Intervals
 
-When examining data, it can be very helpful to plot data as a [CDF](https://en.wikipedia.org/wiki/Cumulative_distribution_function).  Producing a CDF essentially amounts to sorting our observed data from smallest to largest.  We hope that the value in the middle of the sorted list is near the median, the value 90% of the way up the list is near the 90th percentile, and so forth.
+When exploring data, it can be very helpful to plot observations as a [CDF](https://en.wikipedia.org/wiki/Cumulative_distribution_function).  Producing a CDF essentially amounts to sorting the observed data from smallest to largest.  We hope that the value in the middle of the sorted list is near the median, the value 90% of the way up the list is near the 90th percentile, and so forth.
 
-When interpreting a CDF, or comparing two of them, one often wishes for something akin to a confidence interval.  Somewhat surprisingly, it is possible to compute these intervals exactly.  (More precisely, suppose we draw a sample of $n$ observations and consider the $i$-th smallest; if we are sampling from *any* continuous probability distribution, then the distribution of the corresponding quantile has a [Beta distribution](https://en.wikipedia.org/wiki/Beta_distribution), $B(i, n-i+1)$.)
+When interpreting a CDF, or comparing two of them, one often wishes for something akin to a confidence interval.  Somewhat surprisingly, it is possible to compute these intervals exactly.[^1]
+
+^1: More precisely, suppose we draw a sample of $n$ observations and consider the $i$-th smallest; if we are sampling from *any* continuous probability distribution, then the distribution of the corresponding quantile has a [Beta distribution](https://en.wikipedia.org/wiki/Beta_distribution), $B(i, n-i+1)$.
 
 For a single data point, the uncertainty around its quantile can be thought of as a confidence interval (actually, a (credible interval)[https://en.wikipedia.org/wiki/Credible_interval], since we know the prior distribution).  If we consider all the data points, then we refer to a confidence band (or credible band)
 

--- a/mirabolic/__init__.py
+++ b/mirabolic/__init__.py
@@ -7,11 +7,3 @@ with open(os.path.join(os.path.dirname(__file__), "version"), mode="r") as fp:
 
 # Tool for plotting CDFs with confidence intervals
 from mirabolic.cdf.cdf_tools import cdf_plot
-
-# Tensorflow loss functions for count data
-from mirabolic.neural_glm.actuarial_loss_functions import (
-    Poisson_link,
-    Poisson_link_with_exposure,
-    Negative_binomial_link,
-    Negative_binomial_link_with_exposure,
-)

--- a/mirabolic/cdf/sample_usage.py
+++ b/mirabolic/cdf/sample_usage.py
@@ -14,12 +14,12 @@ data = np.random.randn(120)
 ##############
 # A basic plot
 #
-# By default, we use a "90% marginal credibility interval",
+# By default, we use a "90% marginal credible interval",
 # which means that if take any data point, there is a 90%
 # probability that it falls within the shaded region above
 # it (so, we should think of a vertical interval).  Note
 # that the chance that *all* the data points jointly fall
-# in their credibility interval is less than 90%; if you
+# in their credible interval is less than 90%; if you
 # want a joint bound, see the next example.
 plt.figure()
 mirabolic.cdf_plot(data=data, seaborn=True)

--- a/mirabolic/neural_glm/__init__.py
+++ b/mirabolic/neural_glm/__init__.py
@@ -1,0 +1,11 @@
+# Tensorflow loss functions for count data
+from mirabolic.neural_glm.actuarial_loss_functions import (
+    # Loss functions
+    Poisson_link,
+    Poisson_link_with_exposure,
+    Negative_binomial_link,
+    Negative_binomial_link_with_exposure,
+    # Metrics
+    mse_poisson_exposure,
+    gini_poisson_exposure,
+)

--- a/mirabolic/neural_glm/basic_glm_nn.py
+++ b/mirabolic/neural_glm/basic_glm_nn.py
@@ -1,6 +1,6 @@
 # Simple neural net implementing a GLM
 
-import actuarial_loss_functions
+import mirabolic.neural_glm as neural_glm
 import numpy as np
 import keras
 from keras.models import Sequential
@@ -33,18 +33,18 @@ def basic_glm_model(num_features=None,
         # "output_dim" = "how many numbers do we predict?"
         output_dim = 1
         if not exposure:
-            loss = actuarial_loss_functions.Poisson_link
+            loss = neural_glm.Poisson_link
         else:
-            loss = actuarial_loss_functions.Poisson_link_with_exposure
+            loss = neural_glm.Poisson_link_with_exposure
             metrics += [
-                actuarial_loss_functions.mse_poisson_exposure,
-                actuarial_loss_functions.gini_poisson_exposure]
+                neural_glm.mse_poisson_exposure,
+                neural_glm.gini_poisson_exposure]
     elif loss == 'Negative Binomial':
         output_dim = 2
         if not exposure:
-            loss = actuarial_loss_functions.Negative_binomial_link
+            loss = neural_glm.Negative_binomial_link
         else:
-            loss = actuarial_loss_functions.Negative_binomial_link_with_exposure  # noqa: E501
+            loss = neural_glm.Negative_binomial_link_with_exposure  # noqa: E501
 
     model = Sequential()
     # Note: bias=False, i.e., no constant term; if you want a constant term,


### PR DESCRIPTION
The Mirabolic repo has two essentially unrelated pieces of code: one part focussing on GLM-equivalent loss functions for neural nets, and a second part that computes and plots CDFs with confidence intervals.  Previously, the key functions were all available at the top level, i.e. if you ran
```
import mirabolic
```
Unfortunately, the import of the neural net code involves importing a number of tensorflow modules, which is fairly slow; if a user only wanted to plot a CDF, the wasted time was unnecessary.

To fix that, we've separated the neural net part into a separate submodule.  There are now two different paths for importing code, e.g.,:
```
import mirabolic
mirabolic.cdf_plot()

import mirabolic.neural_glm as neural_glm
neural_glm.Poisson_link
```

We also cleaned up the README quite a bit.